### PR TITLE
fix outdated api call

### DIFF
--- a/twitter-mass-unfollow.py
+++ b/twitter-mass-unfollow.py
@@ -22,7 +22,7 @@ api = twitter.Api(consumer_key='#####', consumer_secret='#####', access_token_ke
 
 start = time.time()
 i = 0
-friends=api.GetFriends()
+friends=api.GetFriendIDs()
 
 while (1):
  try:


### PR DESCRIPTION
using GetFriendIDs() instead of GetFriends() solves ratelimit issue
